### PR TITLE
feat: redirect logged-in users from homepage to /dashboard

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,13 @@
 import { clerkMiddleware } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
-export default clerkMiddleware();
+export default clerkMiddleware(async (auth, req) => {
+  const { userId } = await auth();
+
+  if (userId && req.nextUrl.pathname === "/") {
+    return NextResponse.redirect(new URL("/dashboard", req.url));
+  }
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
If a user is authenticated and accesses the root homepage (/), they are now redirected to /dashboard via Clerk middleware.