### PR TITLE
fix: protect /dashboard routes from unauthenticated access

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,11 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
+const isProtectedRoute = createRouteMatcher(["/dashboard(.*)"]);
+
 export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) await auth.protect();
+
   const { userId } = await auth();
 
   if (userId && req.nextUrl.pathname === "/") {


### PR DESCRIPTION
Fixes unauthenticated access to `/dashboard` causing an Application Error.

Adds `createRouteMatcher` for `/dashboard(.*)` in middleware and calls `auth.protect()` so unauthenticated users are redirected to sign-in instead of receiving an Unauthorized error.

Closes #5

Generated with [Claude Code](https://claude.ai/code)